### PR TITLE
fix: runtime parameters

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: install zig
         run: |
-          ZIG_VERSION=0.13.0
+          ZIG_VERSION=0.14.0-dev.1820+ea527f7a8
           wget https://ziglang.org/builds/zig-linux-x86_64-$ZIG_VERSION.tar.xz
           tar xf zig-linux-x86_64-$ZIG_VERSION.tar.xz
           mv zig-linux-x86_64-$ZIG_VERSION $HOME/zig-build

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install zig
         run: |
-          ZIG_VERSION=0.13.0
+          ZIG_VERSION=0.14.0-dev.1820+ea527f7a8
           wget https://ziglang.org/builds/zig-linux-x86_64-$ZIG_VERSION.tar.xz
           tar xf zig-linux-x86_64-$ZIG_VERSION.tar.xz
           mv zig-linux-x86_64-$ZIG_VERSION $HOME/zig-build

--- a/src/protocol/packet.zig
+++ b/src/protocol/packet.zig
@@ -58,7 +58,7 @@ pub const PayloadReader = struct {
     }
 
     pub fn readInt(p: *PayloadReader, Int: type) Int {
-        const bytes = p.readRefComptime(@divExact(@typeInfo(Int).Int.bits, 8));
+        const bytes = p.readRefComptime(@divExact(@typeInfo(Int).int.bits, 8));
         return std.mem.readInt(Int, bytes, .little);
     }
 

--- a/src/protocol/packet_writer.zig
+++ b/src/protocol/packet_writer.zig
@@ -101,7 +101,7 @@ pub const PacketWriter = struct {
     }
 
     pub fn writeInt(p: *PacketWriter, comptime Int: type, int: Int) !void {
-        const bytes = try p.advanceComptime(@divExact(@typeInfo(Int).Int.bits, 8));
+        const bytes = try p.advanceComptime(@divExact(@typeInfo(Int).int.bits, 8));
         std.mem.writeInt(Int, bytes, int, .little);
     }
 

--- a/src/result.zig
+++ b/src/result.zig
@@ -225,7 +225,7 @@ pub const BinaryResultRow = struct {
     }
 
     fn structFreeDynamic(s: anytype, allocator: std.mem.Allocator) void {
-        const s_ti = @typeInfo(@TypeOf(s)).Struct;
+        const s_ti = @typeInfo(@TypeOf(s)).@"struct";
         inline for (s_ti.fields) |field| {
             structFreeStr(field.type, @field(s, field.name), allocator);
         }
@@ -233,13 +233,13 @@ pub const BinaryResultRow = struct {
 
     fn structFreeStr(comptime StructField: type, value: StructField, allocator: std.mem.Allocator) void {
         switch (@typeInfo(StructField)) {
-            .Pointer => |p| switch (@typeInfo(p.child)) {
-                .Int => |int| if (int.bits == 8) {
+            .pointer => |p| switch (@typeInfo(p.child)) {
+                .int => |int| if (int.bits == 8) {
                     allocator.free(value);
                 },
                 else => {},
             },
-            .Optional => |o| if (value) |some| structFreeStr(o.child, some, allocator),
+            .optional => |o| if (value) |some| structFreeStr(o.child, some, allocator),
             else => {},
         }
     }


### PR DESCRIPTION
- Update to zig `0.14.0-dev.1820+ea527f7a8`
- `comptime_int` type is treated as mysql int64 column
- Fixes query execution where parameter is runtime