### PR TITLE
Add support for Zig arrays as MySql values

### DIFF
--- a/src/conversion.zig
+++ b/src/conversion.zig
@@ -264,6 +264,37 @@ inline fn binElemToValue(
                 }
             }
         },
+        .array => |array| {
+            switch (@typeInfo(array.child)) {
+                .int => |int| {
+                    if (int.bits == 8) {
+                        switch (col_type) {
+                            .MYSQL_TYPE_STRING,
+                            .MYSQL_TYPE_VARCHAR,
+                            .MYSQL_TYPE_VAR_STRING,
+                            .MYSQL_TYPE_ENUM,
+                            .MYSQL_TYPE_SET,
+                            .MYSQL_TYPE_LONG_BLOB,
+                            .MYSQL_TYPE_MEDIUM_BLOB,
+                            .MYSQL_TYPE_BLOB,
+                            .MYSQL_TYPE_TINY_BLOB,
+                            .MYSQL_TYPE_GEOMETRY,
+                            .MYSQL_TYPE_BIT,
+                            .MYSQL_TYPE_DECIMAL,
+                            .MYSQL_TYPE_NEWDECIMAL,
+                            => {
+                                const str = reader.readLengthEncodedString();
+                                var ret: [array.len]u8 = undefined;
+                                @memcpy(ret[0..@min(str.len, array.len)], str);
+                                return ret;
+                            },
+                            else => {},
+                        }
+                    }
+                },
+                else => {},
+            }
+        },
         else => {},
     }
 

--- a/src/conversion.zig
+++ b/src/conversion.zig
@@ -284,10 +284,17 @@ inline fn binElemToValue(
                             .MYSQL_TYPE_NEWDECIMAL,
                             => {
                                 const str = reader.readLengthEncodedString();
-                                var ret: [array.len]u8 = undefined;
-                                const min = @min(str.len, array.len);
-                                @memcpy(ret[0..min], str[0..min]);
-                                return ret;
+                                if (array.sentinel()) |sentinel| {
+                                    var ret: [array.len:sentinel]u8 = [_:sentinel]u8{sentinel} ** array.len;
+                                    const min = @min(str.len, array.len);
+                                    @memcpy(ret[0..min], str[0..min]);
+                                    return ret;
+                                } else {
+                                    var ret: [array.len]u8 = [_]u8{0} ** array.len;
+                                    const min = @min(str.len, array.len);
+                                    @memcpy(ret[0..min], str[0..min]);
+                                    return ret;
+                                }
                             },
                             else => {},
                         }

--- a/src/conversion.zig
+++ b/src/conversion.zig
@@ -285,7 +285,8 @@ inline fn binElemToValue(
                             => {
                                 const str = reader.readLengthEncodedString();
                                 var ret: [array.len]u8 = undefined;
-                                @memcpy(ret[0..@min(str.len, array.len)], str);
+                                const min = @min(str.len, array.len);
+                                @memcpy(ret[0..min], str[0..min]);
                                 return ret;
                             },
                             else => {},


### PR DESCRIPTION
I am conflicted on how to handle insufficiently-sized arrays.

In this PR, I just truncate the data to fit the array, but in Connector/C they return an error indicating that a short-read was performed.

Would like to hear your opinion on this.

EDIT: Forgot to mention that this should be used for fixed-length MySql columns (i.e. a hash of 16-bytes), so maybe it is a user error to pass an incorrectly-sized array?