### PR TITLE
fix: precedence, Zig 0.17 API migration, and ResultSet.first() dangling pointer

### DIFF
--- a/integration_tests/conn.zig
+++ b/integration_tests/conn.zig
@@ -281,7 +281,7 @@ test "prepare execute - first" {
 
         const expected = MyType{ .a = 1 };
 
-        const first = try rows.first();
+        const first = try rows.first(allocator);
         try std.testing.expect(first != null);
 
         var value: MyType = undefined;
@@ -302,7 +302,7 @@ test "prepare execute - first" {
         const query_res = try c.executeRows(allocator, &prep_stmt, .{});
         const rows = try query_res.expect(.rows);
 
-        const first = try rows.first();
+        const first = try rows.first(allocator);
         try std.testing.expectEqual(null, first);
         try c.ping();
     }

--- a/integration_tests/conn.zig
+++ b/integration_tests/conn.zig
@@ -282,6 +282,7 @@ test "prepare execute - first" {
         const expected = MyType{ .a = 1 };
 
         const first = try rows.first(allocator);
+        defer if (first) |f| f.deinit(allocator);
         try std.testing.expect(first != null);
 
         var value: MyType = undefined;
@@ -303,6 +304,7 @@ test "prepare execute - first" {
         const rows = try query_res.expect(.rows);
 
         const first = try rows.first(allocator);
+        defer if (first) |f| f.deinit(allocator);
         try std.testing.expectEqual(null, first);
         try c.ping();
     }

--- a/integration_tests/pool.zig
+++ b/integration_tests/pool.zig
@@ -304,7 +304,7 @@ test "prepare execute - first" {
 
         const expected = MyType{ .a = 1 };
 
-        const first = try rows.first();
+        const first = try rows.first(allocator);
         try std.testing.expect(first != null);
 
         var value: MyType = undefined;
@@ -325,7 +325,7 @@ test "prepare execute - first" {
         const query_res = try mc.executeRows(allocator, &prep_stmt, .{});
         const rows = try query_res.expect(.rows);
 
-        const first = try rows.first();
+        const first = try rows.first(allocator);
         try std.testing.expectEqual(null, first);
         try mc.ping();
     }

--- a/integration_tests/pool.zig
+++ b/integration_tests/pool.zig
@@ -305,6 +305,7 @@ test "prepare execute - first" {
         const expected = MyType{ .a = 1 };
 
         const first = try rows.first(allocator);
+        defer if (first) |f| f.deinit(allocator);
         try std.testing.expect(first != null);
 
         var value: MyType = undefined;
@@ -326,6 +327,7 @@ test "prepare execute - first" {
         const rows = try query_res.expect(.rows);
 
         const first = try rows.first(allocator);
+        defer if (first) |f| f.deinit(allocator);
         try std.testing.expectEqual(null, first);
         try mc.ping();
     }

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -28,7 +28,8 @@ const TextResultRow = result.TextResultRow;
 const BinaryResultRow = result.BinaryResultRow;
 const ResultMeta = @import("./result_meta.zig").ResultMeta;
 
-const max_packet_size = 1 << 24 - 1;
+// Maximum allowed MySQL packet size (16MB - 1 bytes)
+const max_packet_size = (1 << 24) - 1;
 
 // TODO: make this adjustable during compile time
 const buffer_size: usize = 4096;

--- a/src/conversion.zig
+++ b/src/conversion.zig
@@ -21,8 +21,10 @@ pub fn scanBinResultRow(dest: anytype, packet: *const Packet, col_defs: []const 
     const struct_field_names = @typeInfo(child_type).@"struct".field_names;
     const struct_field_types = @typeInfo(child_type).@"struct".field_types;
 
-    if (struct_field_names.len != struct_field_types.len and (struct_field_names != col_defs.len)) {
-        std.log.err("received {d} columns from mysql, but given {d} fields for struct", .{ struct_field_names.len, col_defs.len });
+    if (struct_field_names.len != col_defs.len) {
+        //left always is `false` and struct_field_names.len always equals struct_field_types.len
+        //if (struct_field_names.len != struct_field_types.len and (struct_field_names != col_defs.len)) {
+        std.log.err("received {d} columns from mysql, but given {d} fields for struct", .{ col_defs.len, struct_field_names.len });
         return error.ColumnAndFieldCountMismatch;
     }
 

--- a/src/result.zig
+++ b/src/result.zig
@@ -175,6 +175,7 @@ pub fn ResultSet(comptime T: type) type {
 
                     var owned_row = row;
                     owned_row.packet = cloned;
+                    owned_row.owned = true;
                     break :blk owned_row;
                 },
             };
@@ -195,6 +196,7 @@ pub fn ResultSet(comptime T: type) type {
 pub const TextResultRow = struct {
     packet: Packet,
     col_defs: []const ColumnDefinition41,
+    owned: bool = false,
 
     pub fn iter(t: *const TextResultRow) TextElemIter {
         return TextElemIter.init(&t.packet);
@@ -202,6 +204,10 @@ pub const TextResultRow = struct {
 
     pub fn textElems(t: *const TextResultRow, allocator: Allocator) !TextElems {
         return TextElems.init(&t.packet, allocator, t.col_defs.len);
+    }
+
+    pub fn deinit(t: *const TextResultRow, allocator: Allocator) void {
+        if (t.owned) t.packet.deinit(allocator);
     }
 };
 
@@ -260,6 +266,7 @@ fn scanTextResultRow(dest: []?[]const u8, packet: *const Packet) void {
 pub const BinaryResultRow = struct {
     packet: Packet,
     col_defs: []const ColumnDefinition41,
+    owned: bool = false,
 
     /// Scan the row into the struct pointed to by `dest`.
     /// String fields (`[]u8`, `[]const u8`) are shallow-copied and point into the row's
@@ -283,6 +290,10 @@ pub const BinaryResultRow = struct {
     pub fn structDestroy(s: anytype, allocator: Allocator) void {
         structFreeDynamic(s.*, allocator);
         allocator.destroy(s);
+    }
+
+    pub fn deinit(b: *const BinaryResultRow, allocator: Allocator) void {
+        if (b.owned) b.packet.deinit(allocator);
     }
 
     fn structFreeDynamic(s: anytype, allocator: Allocator) void {

--- a/src/result.zig
+++ b/src/result.zig
@@ -153,15 +153,29 @@ pub fn ResultSet(comptime T: type) type {
 
         /// Return the first row of the result set, draining remaining rows.
         /// Returns `null` if the result set is empty.
-        pub fn first(r: *const ResultSet(T)) !?T {
+        /// `allocator` is used to clone the first row's packet so it survives
+        /// the drain loop (which may reallocate the reader buffer).
+        /// The returned row's packet data is heap-allocated and valid for the
+        /// row's lifetime; a small amount of heap memory leaks when the row
+        /// goes out of scope.
+        pub fn first(r: *const ResultSet(T), allocator: Allocator) !?T {
             const row_res = try r.readRow();
             return switch (row_res) {
                 .ok => null,
                 .err => |err| err.asError(),
                 .row => |row| blk: {
+                    // Clone the first row's packet into owned memory before
+                    // draining remaining rows, which may reallocate/free the
+                    // reader buffer and invalidate the original packet payload.
+                    const cloned = try row.packet.cloneAlloc(allocator);
+                    errdefer allocator.free(cloned.payload);
+
                     const i = r.iter();
                     while (try i.next()) |_| {}
-                    break :blk row;
+
+                    var owned_row = row;
+                    owned_row.packet = cloned;
+                    break :blk owned_row;
                 },
             };
         }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 fn numSlice(comptime N: usize, shape: *const [N]usize) usize {
     return switch (N) {
-        0 => return 0,
-        1 => return shape[0],
+        0 => 0,
+        1 => shape[0],
         else => numSlice(N - 1, shape[1..]) * shape[0] + shape[0],
     };
 }


### PR DESCRIPTION

- conn.zig: fix max_packet_size constant precedence (1 << 24 - 1 parsed
  as 1 << (24 - 1) = 8MB in Zig 0.17; should be (1 << 24) - 1 = 16MB)

- conversion.zig: migrate @typeInfo fields access to field_names/field_types
  for Zig 0.17 compat

- packet_reader.zig: update buf.len after allocator.resize instead of
  reassigning the slice

- packet_writer.zig: add missing buf.len update after allocator.resize

- result.zig: migrate structFreeDynamic to field_names/field_types; fix
  ResultSet.first() to clone the first row's packet before draining
  remaining rows — the drain loop may trigger reader buffer reallocation,
  invalidating the original packet payload

- utils.zig: remove redundant return inside switch arms in numSlice

- integration_tests: update first() calls to pass allocator