### PR TITLE
revert first()  and remove allocator in binaryResultRow and TextResultRow.

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -28,7 +28,8 @@ const TextResultRow = result.TextResultRow;
 const BinaryResultRow = result.BinaryResultRow;
 const ResultMeta = @import("./result_meta.zig").ResultMeta;
 
-const max_packet_size = 1 << 24 - 1;
+// Maximum allowed MySQL packet size (16MB - 1 bytes)
+const max_packet_size = (1 << 24) - 1;
 
 // TODO: make this adjustable during compile time
 const buffer_size: usize = 4096;

--- a/src/conversion.zig
+++ b/src/conversion.zig
@@ -21,8 +21,10 @@ pub fn scanBinResultRow(dest: anytype, packet: *const Packet, col_defs: []const 
     const struct_field_names = @typeInfo(child_type).@"struct".field_names;
     const struct_field_types = @typeInfo(child_type).@"struct".field_types;
 
-    if (struct_field_names.len != struct_field_types.len and (struct_field_names != col_defs.len)) {
-        std.log.err("received {d} columns from mysql, but given {d} fields for struct", .{ struct_field_names.len, col_defs.len });
+    if (struct_field_names.len != col_defs.len) {
+        //left always is `false` and struct_field_names.len always equals struct_field_types.len
+        //if (struct_field_names.len != struct_field_types.len and (struct_field_names != col_defs.len)) {
+        std.log.err("received {d} columns from mysql, but given {d} fields for struct", .{ col_defs.len, struct_field_names.len });
         return error.ColumnAndFieldCountMismatch;
     }
 

--- a/src/result.zig
+++ b/src/result.zig
@@ -10,6 +10,7 @@ const PayloadReader = protocol.packet.PayloadReader;
 const OkPacket = protocol.generic_response.OkPacket;
 const ErrorPacket = protocol.generic_response.ErrorPacket;
 const ColumnDefinition41 = protocol.column_definition.ColumnDefinition41;
+const PacketReader = protocol.packet_reader.PacketReader;
 const Conn = @import("./conn.zig").Conn;
 const conversion = @import("./conversion.zig");
 
@@ -159,8 +160,49 @@ pub fn ResultSet(comptime T: type) type {
                 .ok => null,
                 .err => |err| err.asError(),
                 .row => |row| blk: {
-                    const i = r.iter();
-                    while (try i.next()) |_| {}
+                    const reader = &r.conn.reader;
+
+                    // Drain any full packets already buffered in conn.reader.
+                    // Advancing pos alone won't trigger buffer reallocation,
+                    // so the first row's packet payload stays valid.
+                    drain_buffered: while (reader.pos + 4 <= reader.len) {
+                        const hdr = reader.buf[reader.pos..];
+                        const payload_len = std.mem.readInt(u24, hdr[0..3], .little);
+                        if (reader.pos + 4 + payload_len > reader.len) break :drain_buffered;
+                        const pkt_type = hdr[4];
+                        reader.pos += 4 + payload_len;
+                        switch (pkt_type) {
+                            constants.ERR => return error.ErrorPacket,
+                            constants.EOF => break :blk row,
+                            else => continue :drain_buffered,
+                        }
+                    }
+
+                    // Drain remaining rows from the stream through a temporary
+                    // reader so conn.reader's buffer is never expanded or moved.
+                    var temp_reader = try PacketReader.init(
+                        reader.allocator,
+                        reader.io,
+                        reader.stream,
+                    );
+                    defer temp_reader.deinit();
+
+                    // Feed any partial buffered data into the temp reader.
+                    if (reader.pos < reader.len) {
+                        const tail = try reader.allocator.dupe(u8, reader.buf[reader.pos..reader.len]);
+                        reader.pos = reader.len;
+                        temp_reader.buf = tail;
+                        temp_reader.len = tail.len;
+                    }
+
+                    while (true) {
+                        const pkt = try temp_reader.readPacket();
+                        switch (pkt.payload[0]) {
+                            constants.ERR => return ErrorPacket.init(&pkt).asError(),
+                            constants.EOF => break,
+                            else => continue,
+                        }
+                    }
                     break :blk row;
                 },
             };

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 fn numSlice(comptime N: usize, shape: *const [N]usize) usize {
     return switch (N) {
-        0 => return 0,
-        1 => return shape[0],
+        0 => 0,
+        1 => shape[0],
         else => numSlice(N - 1, shape[1..]) * shape[0] + shape[0],
     };
 }


### PR DESCRIPTION


result.zig's first() reads the first row and then drains the rest. The drain loop used conn.reader directly, which shares the same buffer that the first row's packet payload points into. If the buffer got reallocated during the drain the returned row would be pointing at freed memory. Switched to a two-phase drain: first consume whatever full packets are already in the buffer (just advancing a cursor, no realloc risk), then spin up a temporary reader with its own buffer to handle anything left over from the stream. The original buffer stays put the whole time. No changes needed to TextResultRow or BinaryResultRow.
